### PR TITLE
Fix req.destroy in shipFile function

### DIFF
--- a/index.js
+++ b/index.js
@@ -418,7 +418,9 @@ Logsene.prototype.shipFile = function (name, data, cb) {
       self.emit('file shipped', {file: name, count: options.logCount})
       self.emit('rt', {count: options.logCount, source: 'logsene', file: name, url: String(options.url), request: null, response: null})
     }
-    req.destroy()
+    setImmediate(function () {
+      req.destroy()
+    })
   })
 }
 


### PR DESCRIPTION
When req.destroy is called req may not be defined because the callback function can be immediately invoked. This pull request wraps req.destroy in setImmediate to fix this.
```
TypeError: Cannot read property 'destroy' of undefined
    at Request._callback (...\node_modules\logsene-js\index.js:421:9)
```