### PR TITLE
sanitize key names for ElasticSearch also in sub-objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,49 @@ function removeFields (fieldList, doc) {
   return doc
 }
 
+// Create a deep clone of an object while allowing caller to rename
+// keys, replace values, or reject key-pairs entirely.
+//
+// Does not modify the source object. Callback receives (key, value)
+// and is expected to return a two-item array [newKey, newValue], or
+// null if the pair should be absent from the resulting object.
+
+function deepConvert (src, cb) {
+  var dest
+
+  if (Array.isArray(src)) {
+    dest = []
+  } else if (src.constructor === Object) {
+    dest = {}
+  }
+
+  if (dest) {
+    for (var key in src) {
+      if (src.hasOwnProperty(key)) {
+        var val = src[key]
+        var newKV = cb(key, val)
+        if (newKV === null) {
+          // skip this field entirely
+          continue
+        }
+
+        var newKey = newKV[0]
+        var newVal = newKV[1]
+
+        if (Array.isArray(newVal) || newVal.constructor === Object) {
+          dest[newKey] = deepConvert(newVal, cb)
+        } else {
+          dest[newKey] = newVal
+        }
+      }
+    }
+  } else {
+    dest = src
+  }
+
+  return dest
+}
+
 /**
  * token - the LOGSENE Token
  * type - type of log (string)
@@ -269,16 +312,15 @@ Logsene.prototype.log = function (level, message, fields, callback) {
   if (disableJsonEnrichment) {
     msg = {}
   }
-  for (var x in fields) {
-    // rename fields for Elasticsearch 2.x
-    if (startsWithUnderscore.test(x) || hasDots.test(x)) {
-      msg[x.replace(/\./g, '_').replace(/^_+/, '')] = fields[x]
+  var esSanitizedFields = deepConvert(fields, function (key, val) {
+    if (typeof val === 'function') {
+      return null
     } else {
-      if (!(typeof fields[x] === 'function')) {
-        msg[x] = fields[x]
-      }
+      return [key.replace(/\./g, '_').replace(/^_+/, ''),
+              val]
     }
-  }
+  })
+  msg = Object.assign(msg, esSanitizedFields)
   if (msg['@timestamp'] && typeof msg['@timestamp'] === 'number') {
     msg['@timestamp'] = new Date(msg['@timestamp'])
   }

--- a/index.js
+++ b/index.js
@@ -145,7 +145,9 @@ function deepConvert (src, cb) {
         var newKey = newKV[0]
         var newVal = newKV[1]
 
-        if (Array.isArray(newVal) || newVal.constructor === Object) {
+        if (newVal !== undefined &&
+            newVal !== null &&
+            (Array.isArray(newVal) || newVal.constructor === Object)) {
           dest[newKey] = deepConvert(newVal, cb)
         } else {
           dest[newKey] = newVal


### PR DESCRIPTION
Since key sanitization stops at base level, indexing in ES fails when sub-objects contain keys with dots, e.g.:

```
{
  req: {
    method: 'get',
    url: '/foo/bar'
  },
  container: {
    Labels: {
      'com.docker.swarm.service_name': 'http'
    }
  }
}
```

This patch applies key sanitization recursively.

(I wrote deepConvert in a way that doesn't mutate arguments just because that's what I'm used to. I can rewrite this in the arg-mutating style of the other transformation if needed.)